### PR TITLE
Require interactor gem

### DIFF
--- a/lib/interactor/rails.rb
+++ b/lib/interactor/rails.rb
@@ -1,6 +1,1 @@
 require "interactor"
-
-module Interactor
-  module Rails
-  end
-end

--- a/spec/interactor/rails_spec.rb
+++ b/spec/interactor/rails_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 module Interactor
-  describe Rails do
+  describe "Rails" do
     before do
       run_simple <<-CMD
         bundle exec rails new example \


### PR DESCRIPTION
Explicitly require the interactor gem so we ensure it is loaded in
a Rails app.
