### PR TITLE
Generate namespaced interactors/organizers in the right directory

### DIFF
--- a/lib/generators/interactor.rb
+++ b/lib/generators/interactor.rb
@@ -5,7 +5,7 @@ module Interactor
     end
 
     def generate
-      template "#{self.class.generator_name}.erb", "app/interactors/#{file_name}.rb"
+      template "#{self.class.generator_name}.erb", File.join("app/interactors", class_path, "#{file_name}.rb")
     end
   end
 end

--- a/spec/interactor/rails_spec.rb
+++ b/spec/interactor/rails_spec.rb
@@ -47,6 +47,22 @@ EOF
           check_file_presence(["app/interactors/place_order.rb"], false)
           assert_partial_output("rails generate interactor NAME", all_stdout)
         end
+
+        it "handles namespacing" do
+          run_simple "bundle exec rails generate interactor invoice/place_order"
+
+          path = "app/interactors/invoice/place_order.rb"
+          check_file_presence([path], true)
+          check_exact_file_content(path, <<-EOF)
+class Invoice::PlaceOrder
+  include Interactor
+
+  def call
+    # TODO
+  end
+end
+EOF
+        end
       end
 
       context "interactor:organizer" do
@@ -88,6 +104,20 @@ EOF
 
           check_file_presence(["app/interactors/place_order.rb"], false)
           assert_partial_output("rails generate interactor:organizer NAME", all_stdout)
+        end
+
+        it "handles namespacing" do
+          run_simple "bundle exec rails generate interactor:organizer invoice/place_order"
+
+          path = "app/interactors/invoice/place_order.rb"
+          check_file_presence([path], true)
+          check_exact_file_content(path, <<-EOF)
+class Invoice::PlaceOrder
+  include Interactor::Organizer
+
+  # organize Interactor1, Interactor2
+end
+EOF
         end
       end
     end


### PR DESCRIPTION
[Fixes #5]

rails g interactor foo/bar should generate app/interactors/foo/bar.rb

currently this generates

``` ruby
class Foo::Bar
  include Interactor

  def call
  end
end
```

which is less than ideal, but follows how Rails does it
