### PR TITLE
Add spec templates.

### DIFF
--- a/lib/generators/interactor.rb
+++ b/lib/generators/interactor.rb
@@ -6,6 +6,7 @@ module Interactor
 
     def generate
       template "#{self.class.generator_name}.erb", File.join("app/interactors", class_path, "#{file_name}.rb")
+      template "spec.erb", File.join("spec/interactors", class_path, "#{file_name}_spec.rb")
     end
   end
 end

--- a/lib/generators/templates/spec.erb
+++ b/lib/generators/templates/spec.erb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+RSpec.describe <%= class_name %>, type: :interactor do
+  describe '.call' do
+    pending "add some examples to (or delete) #{__FILE__}"
+  end
+end

--- a/spec/interactor/rails_spec.rb
+++ b/spec/interactor/rails_spec.rb
@@ -28,7 +28,7 @@ module Interactor
 
     context "rails generate" do
       context "interactor" do
-        it "generates an interactor" do
+        it "generates an interactor and spec" do
           run_simple "bundle exec rails generate interactor place_order"
 
           path = "app/interactors/place_order.rb"
@@ -39,6 +39,18 @@ class PlaceOrder
 
   def call
     # TODO
+  end
+end
+EOF
+
+          path = 'spec/interactors/place_order_spec.rb'
+          expect(path).to be_an_existing_file
+          expect(path).to have_file_content(<<-EOF)
+require 'spec_helper'
+
+RSpec.describe PlaceOrder, type: :interactor do
+  describe '.call' do
+    pending "add some examples to (or delete) \#{__FILE__}"
   end
 end
 EOF
@@ -65,6 +77,18 @@ class Invoice::PlaceOrder
   end
 end
 EOF
+
+          path = "spec/interactors/invoice/place_order_spec.rb"
+          expect(path).to be_an_existing_file
+          expect(path).to have_file_content(<<-EOF)
+require 'spec_helper'
+
+RSpec.describe Invoice::PlaceOrder, type: :interactor do
+  describe '.call' do
+    pending "add some examples to (or delete) \#{__FILE__}"
+  end
+end
+EOF
         end
       end
 
@@ -81,6 +105,18 @@ class PlaceOrder
   include Interactor::Organizer
 
   # organize Interactor1, Interactor2
+end
+EOF
+
+          path = "spec/interactors/place_order_spec.rb"
+          expect(path).to be_an_existing_file
+          expect(path).to have_file_content(<<-EOF)
+require 'spec_helper'
+
+RSpec.describe PlaceOrder, type: :interactor do
+  describe '.call' do
+    pending "add some examples to (or delete) \#{__FILE__}"
+  end
 end
 EOF
         end
@@ -119,6 +155,18 @@ class Invoice::PlaceOrder
   include Interactor::Organizer
 
   # organize Interactor1, Interactor2
+end
+EOF
+
+          path = "spec/interactors/invoice/place_order_spec.rb"
+          expect(path).to be_an_existing_file
+          expect(path).to have_file_content(<<-EOF)
+require 'spec_helper'
+
+RSpec.describe Invoice::PlaceOrder, type: :interactor do
+  describe '.call' do
+    pending "add some examples to (or delete) \#{__FILE__}"
+  end
 end
 EOF
         end


### PR DESCRIPTION
* Generates spec/interactors/your_interactor_spec.rb
* Fixes Deprecation: The use of "check_exact_file_content" is deprecated. Use "#check_file_content" with a string instead.

Fixes #3