### PR TITLE
Fix Ruby 1.9 / Rails 4.x Travis CI build

### DIFF
--- a/gemfiles/rails40.gemfile
+++ b/gemfiles/rails40.gemfile
@@ -3,6 +3,8 @@ source "https://rubygems.org"
 gemspec path: ".."
 
 gem "rails", "~> 4.0.0"
+gem "mime-types", "< 3.0", platform: [:mri_19]
+
 
 group :test do
   gem "aruba"

--- a/gemfiles/rails41.gemfile
+++ b/gemfiles/rails41.gemfile
@@ -3,6 +3,7 @@ source "https://rubygems.org"
 gemspec path: ".."
 
 gem "rails", "~> 4.1.0"
+gem "mime-types", "< 3.0", platform: [:mri_19]
 
 group :test do
   gem "aruba"

--- a/gemfiles/rails42.gemfile
+++ b/gemfiles/rails42.gemfile
@@ -3,6 +3,7 @@ source "https://rubygems.org"
 gemspec path: ".."
 
 gem "rails", "~> 4.2.0"
+gem "mime-types", "< 3.0", platform: [:mri_19]
 
 group :test do
   gem "aruba"


### PR DESCRIPTION
Recently mime-types 3 included a dependency on mime-types-data which is Ruby 2+ only. When bundler
resolved the bundle update on travis it picked the latest version of mime-types even when being run on Ruby 1.9 versions. This should hopefully resolve that issue by requiring a version of mime types <= 3.0 for the combination of Ruby 1.9 and Rails 4.x.