### PR TITLE
Use Codeclimate reporter v1.0.0 in a Travis after_success hook

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+after_success:
+  - bundle exec codeclimate-test-reporter
 before_install:
   - gem update bundler rake
 branches:

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,6 @@ gem "rails"
 
 group :test do
   gem "aruba"
-  gem "codeclimate-test-reporter", require: false
+  gem "codeclimate-test-reporter", "~> 1.0"
   gem "rspec"
 end

--- a/gemfiles/rails42.gemfile
+++ b/gemfiles/rails42.gemfile
@@ -7,6 +7,6 @@ gem "mime-types", "< 3.0", platform: [:mri_19]
 
 group :test do
   gem "aruba"
-  gem "codeclimate-test-reporter", require: false
+  gem "codeclimate-test-reporter", "~> 1.0"
   gem "rspec"
 end

--- a/gemfiles/rails50.gemfile
+++ b/gemfiles/rails50.gemfile
@@ -6,6 +6,6 @@ gem "rails", ">= 5.0.0.beta", "< 5.1"
 
 group :test do
   gem "aruba"
-  gem "codeclimate-test-reporter", require: false
+  gem "codeclimate-test-reporter", "~> 1.0"
   gem "rspec"
 end

--- a/gemfiles/rails51+.gemfile
+++ b/gemfiles/rails51+.gemfile
@@ -6,6 +6,6 @@ gem "rails", ">= 5.1"
 
 group :test do
   gem "aruba"
-  gem "codeclimate-test-reporter", require: false
+  gem "codeclimate-test-reporter", "~> 1.0"
   gem "rspec"
 end

--- a/gemfiles/rails51.gemfile
+++ b/gemfiles/rails51.gemfile
@@ -6,6 +6,6 @@ gem "rails", "~> 5.1.0"
 
 group :test do
   gem "aruba"
-  gem "codeclimate-test-reporter", require: false
+  gem "codeclimate-test-reporter", "~> 1.0"
   gem "rspec"
 end


### PR DESCRIPTION
This PR updates the codeclimate-test-reporter and attaches it to the `after_success` hook.

- [x] Add a CODECLIMATE_REPO_TOKEN