### PR TITLE
allow Rails 6

### DIFF
--- a/interactor-rails.gemspec
+++ b/interactor-rails.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.test_files = spec.files.grep(/^spec/)
 
   spec.add_dependency "interactor", "~> 3.0"
-  spec.add_dependency "rails", ">= 4.2", "< 5.3"
+  spec.add_dependency "rails", ">= 4.2", "< 6.1"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
Tests are passing in Rails 6, so the Gemspec should not restrict the Rails version to 5.2 or below.

![6](https://user-images.githubusercontent.com/530/51713910-613cc080-2098-11e9-9d3f-19b0694bacd3.gif)
