### PR TITLE
Support for rails 6.0.0.rc1

### DIFF
--- a/gemfiles/rails52+.gemfile
+++ b/gemfiles/rails52+.gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gemspec path: ".."
 
-gem "rails", ">= 5.2"
+gem "rails", ">= 6.0.0.rc1"
 
 group :test do
   gem "aruba"

--- a/interactor-rails.gemspec
+++ b/interactor-rails.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name    = "interactor-rails"
-  spec.version = "2.2.0"
+  spec.version = "2.2.1"
 
   spec.author      = "Collective Idea"
   spec.email       = "info@collectiveidea.com"
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.test_files = spec.files.grep(/^spec/)
 
   spec.add_dependency "interactor", "~> 3.0"
-  spec.add_dependency "rails", ">= 4.2", "< 6.1"
+  spec.add_dependency "rails", ">= 4.2"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"

--- a/interactor-rails.gemspec
+++ b/interactor-rails.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.test_files = spec.files.grep(/^spec/)
 
   spec.add_dependency "interactor", "~> 3.0"
-  spec.add_dependency "rails", ">= 4.2", "< 5.3"
+  spec.add_dependency "rails", ">= 4.2", "< 6.1"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
I am using this in product at my company. The tests pass for me locally.

It appears that the bundler version in the travis config may be out of date?