### PR TITLE
Updates doc about the compatibility with rails 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ gem "interactor-rails", "~> 2.0"
 ```
 
 Interactor Rails is compatible with Ruby 2.3, 2.4, or 2.5 on Rails 4.2, 5.0,
-5.1, or 5.2.
+5.1, 5.2 or 6.0.
 
 ## Usage
 


### PR DESCRIPTION
> The community claims for compatibility with rails 6. Since I saw movements from the authors and contributors to make this happen, this is my 50 cents.

This PR aims to update the documentation when the bumped version on ruby gems becomes available.