### PR TITLE
bumps to interactor 3.1.2 to fix ruby 2.7 failures

### DIFF
--- a/interactor-rails.gemspec
+++ b/interactor-rails.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.files      = `git ls-files`.split($/)
   spec.test_files = spec.files.grep(/^spec/)
 
-  spec.add_dependency "interactor", "~> 3.0"
+  spec.add_dependency "interactor", "~> 3.1.2"
   spec.add_dependency "rails", ">= 4.2"
 
   spec.add_development_dependency "bundler"


### PR DESCRIPTION
the new version of the interactor gem fixes an issue with ruby 2.7 and context.fail!
Let me know if the changelog needs to be updated with this change